### PR TITLE
Add poetry.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ coverage.xml
 # mypy
 .mypy_cache/
 
+# poetry lock
+poetry.lock


### PR DESCRIPTION
Add poetry.lock to gitignore as recommended in [Poetry's docs](https://poetry.eustace.io/docs/basic-usage/#commit-your-poetrylock-file-to-version-control)