### PR TITLE
Fix annotation docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ lint:
 
 # Docs
 docs:
-	mkdocs serve
+	poetry run mkdocs serve
 
 # Building and publishing
 build: unit-tests lint

--- a/docs/api/annotations.md
+++ b/docs/api/annotations.md
@@ -41,7 +41,7 @@ Example:
 ```python
 from pycaprio.mappings import InceptionFormat, AnnotationState
 with open("annotation") as annotation_file:
-    new_annotation = client.api.create_annotation(1, 4, 'leonardo-dicaprio', annotation_format=InceptionFormat.WEBANNO, annotation_state=AnnotationState.ANNOTATION_IN_PROGRESS)
+    new_annotation = client.api.create_annotation(1, 4, 'leonardo-dicaprio', annotation_file, annotation_format=InceptionFormat.WEBANNO, annotation_state=AnnotationState.ANNOTATION_IN_PROGRESS)
 print(new_annotation) # <Annotation by leonardo-dicaprio (Project: 1, Document: 4)>
 ```
 


### PR DESCRIPTION
* Fix **Upload annotation** documentation: Was calling `create_annotation` with no annotation content.
* Fix `make docs` so it runs through poetry.


Fixes #15 